### PR TITLE
Import TaggableStore

### DIFF
--- a/src/Traits/LaravelEntrustRoleTrait.php
+++ b/src/Traits/LaravelEntrustRoleTrait.php
@@ -12,6 +12,7 @@
 
 namespace Shanmuga\LaravelEntrust\Traits;
 
+use Illuminate\Cache\TaggableStore;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 


### PR DESCRIPTION
TaggableStore doesn't imported from Illuminate\Cache\TaggableStore. Causing permissions doesn't properly cached (hit db multiple times).